### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,5 +184,5 @@ See LICENSE_ for details.
 .. |python3| image:: https://caniusepython3.com/project/touchworks.svg
     :target: https://caniusepython3.com/project/touchworks
 
-.. |wheel| image:: https://pypip.in/wheel/touchworks/badge.png
+.. |wheel| image:: https://img.shields.io/pypi/wheel/touchworks.svg
     :target: https://pypi.python.org/pypi/touchworks/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20touchworks))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `touchworks`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.